### PR TITLE
use i64::MAX instead of 0x3f3f3f3f3f3f3f3f

### DIFF
--- a/src/graph/flow.rs
+++ b/src/graph/flow.rs
@@ -13,7 +13,7 @@ pub struct FlowGraph {
 
 impl FlowGraph {
     /// An upper limit to the flow.
-    const INF: i64 = 0x3f3f_3f3f_3f3f_3f3f;
+    const INF: i64 = i64::MAX;
 
     /// Initializes an flow network with vmax vertices and no edges.
     pub fn new(vmax: usize, emax_hint: usize) -> Self {


### PR DESCRIPTION
seems more rusty to use built-in constants

it seems that 0x3f3f... is used in competitive programming because...

1. it is around 2^62 so you can double it without overflowing `i64`. However it doesn't seem to matter here.
2. it is easy to type and remember, especially in c++ where you have to `include <numeric_limits>` and use `std::numeric_limits<int64_t>::max()`. But in rust `i64::MAX` is easier to type.
3. you can do `memset(..., 0x3f, ...)` tricks. But here we are initializing with `vec![Self::INF; self.graph.num_v()]` which should have compiler optimizations anyway.

tests seem to pass...