### PR TITLE
Add Codechef to supported websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To my delight, I found that Rust eliminates entire classes of bugs, while reduci
 
 Some contest sites and online judges that support Rust:
 - [Codeforces](https://codeforces.com)
+- [Codechef](https://www.codechef.com)
 - [AtCoder](https://atcoder.jp)
 - [Kattis](https://open.kattis.com/help/rust)
 - [SPOJ](https://www.spoj.com/)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To my delight, I found that Rust eliminates entire classes of bugs, while reduci
 
 Some contest sites and online judges that support Rust:
 - [Codeforces](https://codeforces.com)
-- [Codechef](https://www.codechef.com)
+- [CodeChef](https://www.codechef.com)
 - [AtCoder](https://atcoder.jp)
 - [Kattis](https://open.kattis.com/help/rust)
 - [SPOJ](https://www.spoj.com/)


### PR DESCRIPTION
Codechef also supports Rust for Competitions as well as Practice problems.